### PR TITLE
Refactor Google OAuth flow to be backend-driven

### DIFF
--- a/backend/oauth_google.py
+++ b/backend/oauth_google.py
@@ -11,7 +11,7 @@ def generate_google_oauth_redirect_uri():
 
     query_params = {
         "client_id": settings.OAUTH_GOOGLE_CLIENT_ID,
-        "redirect_uri": "http://localhost:3000/auth/google",
+        "redirect_uri": "http://localhost:8000/auth/google/callback",
         "response_type": "code",
         "scope": " ".join([
             "https://www.googleapis.com/auth/drive",

--- a/frontend/src/components/AuthGoogle.vue
+++ b/frontend/src/components/AuthGoogle.vue
@@ -33,28 +33,16 @@ export default {
   },
   mounted() {
     const queryParams = new URLSearchParams(window.location.search);
-    const code = queryParams.get('code')
-    const state = queryParams.get('state')
+    const userName = queryParams.get('userName');
+    const picUrl = queryParams.get('picUrl');
+    const fileNames = queryParams.get('fileNames');
 
-    if (code && state) {
-      fetch('http://localhost:8000/auth/google/callback', {
-        body: JSON.stringify({ code, state }),
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      })
-        .then(res => {
-          if (!res.ok) {
-            throw new Error('Ошибка сервера')
-          }
-          return res.json()
-        })
-        .then(data => {
-          this.picUrl = data.user.picture
-          this.userName = data.user.name
-          this.fileNames = data.files
-        })
+    if (userName && picUrl) {
+      this.userName = userName;
+      this.picUrl = picUrl;
+      this.fileNames = fileNames ? fileNames.split(',') : [];
     } else {
-      this.message = '⚠️ Нет параметра code';
+      this.message = '⚠️ Не удалось получить данные пользователя.';
     }
   },
 };


### PR DESCRIPTION
This commit refactors the Google OAuth 2.0 flow. Instead of having the frontend act as an intermediary, Google now redirects directly to the backend FastAPI endpoint.

The new flow is as follows:
1. The user is redirected to Google for authentication.
2. Google redirects the user back to a GET endpoint on the FastAPI backend with an authorization code.
3. The backend exchanges the code for tokens, fetches user info and a list of Google Drive files.
4. The backend then redirects the user to the frontend, passing the fetched data as URL query parameters.
5. The frontend component reads the data from the URL to display it.